### PR TITLE
Added toggleable visibility of world

### DIFF
--- a/src/main/java/net/zlt/live_main_menu/Config.java
+++ b/src/main/java/net/zlt/live_main_menu/Config.java
@@ -18,14 +18,20 @@ public class Config {
         .comment("The FOV of the camera in the live main menu.")
         .defineInRange("liveMainMenuFov", 70, 30, 110);
 
+    private static final ModConfigSpec.BooleanValue HIDE_WORLD = BUILDER
+            .comment("Whether to hide the world used in the menu from the singleplayer selection screen.")
+            .define("hideWorld", true);
+
     static final ModConfigSpec SPEC = BUILDER.build();
 
     public static boolean useCustomFov;
     public static int liveMainMenuFov;
+    public static boolean hideWorld;
 
     @SubscribeEvent
     public static void onLoad(ModConfigEvent event) {
         useCustomFov = USE_CUSTOM_FOV.get();
         liveMainMenuFov = LIVE_MAIN_MENU_FOV.get();
+        hideWorld = HIDE_WORLD.get();
     }
 }

--- a/src/main/java/net/zlt/live_main_menu/mixin/WorldSelectionListMixin.java
+++ b/src/main/java/net/zlt/live_main_menu/mixin/WorldSelectionListMixin.java
@@ -1,0 +1,19 @@
+package net.zlt.live_main_menu.mixin;
+
+import net.minecraft.client.gui.screens.worldselection.WorldSelectionList;
+import net.minecraft.world.level.storage.LevelSummary;
+import net.zlt.live_main_menu.Config;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(WorldSelectionList.class)
+public class WorldSelectionListMixin {
+
+    @Inject(method = "filterAccepts", at = @At("HEAD"), cancellable = true)
+    private void restrictWorld(String filter, LevelSummary level, CallbackInfoReturnable<Boolean> cir) {
+        if(!Config.hideWorld) return;
+        if(level.getLevelId().equalsIgnoreCase("LiveMainMenu") || level.getLevelName().equalsIgnoreCase("LiveMainMenu")) cir.setReturnValue(false);
+    }
+}

--- a/src/main/resources/assets/live_main_menu/lang/en_us.json
+++ b/src/main/resources/assets/live_main_menu/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "live_main_menu.menu.savingLevel": "Saving LiveMainMenu world",
   "live_main_menu.configuration.useCustomFov": "Use Custom FOV",
-  "live_main_menu.configuration.liveMainMenuFov": "Live Main Menu FOV"
+  "live_main_menu.configuration.liveMainMenuFov": "Live Main Menu FOV",
+  "live_main_menu.configuration.hideWorld": "Hide World"
 }

--- a/src/main/resources/live_main_menu.mixins.json
+++ b/src/main/resources/live_main_menu.mixins.json
@@ -12,6 +12,7 @@
     "RealmsNotificationsScreenMixin",
     "WorldListEntryMixin",
     "WorldOpenFlowsMixin",
+    "WorldSelectionListMixin",
     "accessor.TitleScreenAccessor"
   ],
   "injectors": {


### PR DESCRIPTION
Context: I used this mod in a private modpack and wanted to prevent the clients from joining the world used in the main menu.

So I just added an extra config option that hides the LiveMainMenu world from the singeplayer world selection screen. Obviously this is meant for modpack creators and alike.
Defaults to being hidden.

Despite being "just" a proof of concept, this is still an amazing work. Thank you.